### PR TITLE
Fix float pattern

### DIFF
--- a/src/renderer/ModSettingsNumberField.tsx
+++ b/src/renderer/ModSettingsNumberField.tsx
@@ -12,7 +12,7 @@ function useIsFocused(): [
   return [isFocused, onFocus, onBlur];
 }
 
-const PATTERN = '^[0-9]*(\\.[0-9]*)?$';
+const PATTERN = '^[0-9]*(\.[0-9]*)?$';
 
 type Props = {
   field: ModConfigFieldNumber;


### PR DESCRIPTION
The current pattern was allowing strings like `1\s1234` which is obviously not a valid number. `\\.` actually matches a `\` character following by any char (`.`).

By getting rid of the extra `\` it now matches a `.` character as expected so we can have proper float values 🙂.

Example: https://regex101.com/r/pZSUOK/1