### PR TITLE
experimental linux support

### DIFF
--- a/.erb/scripts/build-casclib-linux.js
+++ b/.erb/scripts/build-casclib-linux.js
@@ -1,0 +1,38 @@
+/**
+ * Builds CascLib.dylib for linux using cmake.
+ *
+ * cmake must be available in PATH.
+ */
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const cascLibDir = path.join(root, 'node_modules', 'CascLib');
+const buildDir = path.join(cascLibDir, 'build');
+const outputDylib = path.join(root, 'tools', 'CascLib.so');
+
+execSync(
+  `cmake -B "${buildDir}" -S "${cascLibDir}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5`,
+  { stdio: 'inherit' },
+);
+execSync(`cmake --build "${buildDir}"`, { stdio: 'inherit' });
+
+// cmake output path varies by cmake version and platform conventions.
+// Check the most likely locations in order.
+const candidates = [
+  path.join(buildDir, 'libCasc.so'),
+  path.join(buildDir, 'libcasc.so'),
+  path.join(buildDir, 'casc.framework', 'Versions', '1.0.0', 'casc'),
+  path.join(buildDir, 'casc.framework', 'casc'),
+];
+
+const builtLib = candidates.find((p) => fs.existsSync(p));
+if (!builtLib) {
+  console.error('Could not find built CascLib dylib. Searched:');
+  candidates.forEach((c) => console.error(' ', c));
+  process.exit(1);
+}
+
+fs.copyFileSync(builtLib, outputDylib);
+console.log(`Copied ${builtLib} -> ${outputDylib}`);

--- a/.erb/scripts/prepackage.js
+++ b/.erb/scripts/prepackage.js
@@ -6,11 +6,20 @@
  */
 const { execSync } = require('child_process');
 
-const isWin = process.platform === 'win32';
-
 function run(script) {
   execSync(`npm run ${script}`, { stdio: 'inherit' });
 }
 
-run(isWin ? 'build:updater:win' : 'build:updater:mac');
-run(isWin ? 'build:casclib:win' : 'build:casclib:mac');
+switch(process.platform){
+  case "win32":
+    run('build:updater:win');
+    run('build:casclib:win');
+    break;
+  case "linux":
+    run('build:updater:linux');
+    run('build:casclib:linux');
+    break;
+  default:
+    run('build:updater:mac');
+    run('build:casclib:mac');
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         run: npm install
 
       - name: Clone CascLib source
-        run: git clone https://github.com/olegbl/CascLib.git node_modules/CascLib
+        run: git clone https://github.com/ladislav-zezula/CascLib.git node_modules/CascLib
 
       - name: Build package
         run: npm run package
@@ -125,7 +125,7 @@ jobs:
         run: npm install
 
       - name: Clone CascLib source
-        run: git clone https://github.com/olegbl/CascLib.git node_modules/CascLib
+        run: git clone https://github.com/ladislav-zezula/CascLib.git node_modules/CascLib
 
       - name: Build package
         run: npm run package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,8 +136,39 @@ jobs:
           name: macos-build
           path: release/build/*.dmg
 
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # GitHub git dependencies don't work in GitHub Action workflows,
+      # so we remove CascLib from package.json and clone it manually instead.
+      - name: Remove CascLib from package.json
+        run: npm remove CascLib --force
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Clone CascLib source
+        run: git clone https://github.com/ladislav-zezula/CascLib.git node_modules/CascLib
+
+      - name: Build package
+        run: npm run package
+
+      - name: Upload linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-build
+          path: release/build/*.zip
+
   release:
-    needs: [check-version, build-windows, build-macos]
+    needs: [check-version, build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Download Windows artifact
@@ -150,6 +181,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: macos-build
+          path: artifacts
+
+      - name: Download linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
           path: artifacts
 
       - name: Delete release

--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ Pre-built DMG releases are available for Apple Silicon Macs (M1/M2/M3/M4). Intel
 Since Diablo II: Resurrected has no native macOS version, you'll need [CrossOver](https://www.codeweavers.com/crossover) to run the game. Launch D2R from CrossOver with the run options: `-mod D2RMM -txt`
 
 Building from source follows the same steps as Windows. `yarn package` produces a `.dmg` in `release/build/`.
+
+## linux support (experimental)
+
+> **Note:** linux support is experimental and not officially supported. Things may not work as expected.
+
+Since Diablo II: Resurrected has no native linux version, you'll need to run the game using external tools (e.g. [Lutris](https://github.com/lutris/lutris)). Launch D2R with the run options: `-mod D2RMM -txt`
+
+Building from source follows the same steps as Windows. `yarn package` produces a `.zip` archive in `release/build/`.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "@yao-pkg/pkg": "^6.14.1",
-    "CascLib": "https://github.com/olegbl/CascLib.git",
+    "CascLib": "https://github.com/ladislav-zezula/CascLib.git",
     "browserslist-config-erb": "^0.0.3",
     "chalk": "^4.1.2",
     "concurrently": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts",
     "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
-    "build:casclib": "node -e \"const {execSync}=require('child_process');execSync(process.platform==='win32'?'npm run build:casclib:win':'npm run build:casclib:mac',{stdio:'inherit'})\"",
+    "build:casclib": "node -e \"const {execSync}=require('child_process');execSync(process.platform==='win32'?'npm run build:casclib:win':(process.platform==='linux'?'npm run build:casclib:linux':'npm run build:casclib:mac'),{stdio:'inherit'})\"",
     "build:casclib:win": "node ./.erb/scripts/build-casclib-win.js",
     "build:casclib:mac": "node ./.erb/scripts/build-casclib-mac.js",
-    "build:updater": "concurrently \"npm run build:updater:win\" \"npm run build:updater:mac\"",
+    "build:casclib:linux": "node ./.erb/scripts/build-casclib-linux.js",
+    "build:updater": "concurrently \"npm run build:updater:win\" \"npm run build:updater:mac\" \"npm run build:updater:linux\"",
     "build:updater:win": "pkg -t node22-win-x64 -o tools/updater.exe src/updater/main.js",
     "build:updater:mac": "pkg -t node22-macos-arm64 -o tools/updater src/updater/main.js",
+    "build:updater:linux": "pkg -t node22-linux-x64 -o tools/updater src/updater/main.js",
     "build:config-schema": "npx typescript-json-schema --strictNullChecks --require --noExtraProps --aliasRefs --out \"mods/config-schema.json\" \"src/bridge/ModConfig.d.ts\" \"ModConfig\"",
     "rebuild": "npx @electron/rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "lint": "node lint.js",
@@ -53,6 +55,9 @@
         }
       ],
       "category": "public.app-category.utilities"
+    },
+    "linux": {
+      "target": ["zip"]
     },
     "protocols": {
       "name": "nxm",

--- a/src/main/worker/CascLib.ts
+++ b/src/main/worker/CascLib.ts
@@ -82,7 +82,8 @@ export async function initCascLib(): Promise<void> {
       libName = 'CascLib.dylib';
       break;
     case 'linux':
-      throw new Error("CascLib hasn't been compiled for Linux.");
+      libName = 'CascLib.so';
+      break;
     default:
       throw new Error(`Unsupported platform: ${process.platform}`);
   }


### PR DESCRIPTION
Following the changes done to implement macos build support it was pretty easy to do the same for linux. The build is functionally the same as the macos one - you can manage mods, but other things like running the game through d2rmm would require some major rework.
The one thing I'm a bit concerned with is the casclib version used - your fork was not working for me so I had to switch to the upstream version. If I understand this correctly, the issue that caused the fork has been solved upstream so this should not be a problem. Unfortunately I have only Battle.net version of the game so I can't confirm if that's the case.